### PR TITLE
Add feature to copy verified boot hash to clipboard

### DIFF
--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/CommonItemViewHolder.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/CommonItemViewHolder.kt
@@ -61,6 +61,9 @@ open class CommonItemViewHolder<T>(itemView: View, binding: HomeCommonItemBindin
                     binding.apply {
                         title.setText(data.title)
                         if (!data.data.isNullOrBlank()) {
+                            if (data.data!!.contains("verifiedBootHash: ")) {
+                                btnCopy.isVisible = true
+                            }
                             summary.text = data.data
                             text1.setText(if (data.tee) R.string.tee_enforced else R.string.sw_enforced)
                             text1.isVisible = true

--- a/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/vvb2060/keyattestation/home/HomeViewModel.kt
@@ -22,6 +22,7 @@ import com.samsung.android.security.keystore.AttestationUtils
 import io.github.vvb2060.keyattestation.AppApplication
 import io.github.vvb2060.keyattestation.attestation.AttestationResult
 import io.github.vvb2060.keyattestation.attestation.CertificateInfo.parseCertificateChain
+import io.github.vvb2060.keyattestation.attestation.RootOfTrust
 import io.github.vvb2060.keyattestation.lang.AttestationException
 import io.github.vvb2060.keyattestation.lang.AttestationException.Companion.CODE_CANT_PARSE_CERT
 import io.github.vvb2060.keyattestation.lang.AttestationException.Companion.CODE_DEVICEIDS_UNAVAILABLE
@@ -294,5 +295,20 @@ class HomeViewModel(pm: PackageManager, private val sp: SharedPreferences) : Vie
         }
 
         attestationResult.postValue(result)
+    }
+
+    fun getRootOfTrust(): RootOfTrust? {
+        val useSAK = hasSAK && preferSAK
+        val useStrongBox = hasStrongBox && preferStrongBox
+        val includeProps = hasDeviceIds && preferIncludeProps
+        val useAttestKey = hasAttestKey && preferAttestKey && !useSAK
+        try {
+            val attestationResult = doAttestation(useSAK, useStrongBox, includeProps, useAttestKey)
+            return attestationResult.rootOfTrust
+        } catch (e: Throwable) {
+            val cause = if (e is AttestationException) e.cause else e
+            Log.w(AppApplication.TAG, "Do attestation error.", cause)
+        }
+        return null
     }
 }

--- a/app/src/main/res/layout/home_common_item.xml
+++ b/app/src/main/res/layout/home_common_item.xml
@@ -3,55 +3,102 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@android:id/content"
     style="@style/HomeCardStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
     android:gravity="center_vertical"
-    android:orientation="horizontal">
+    android:orientation="vertical">
 
     <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:baselineAligned="false"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/title"
+                style="@style/HomeItemTitleText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="title" />
+
+            <TextView
+                android:id="@+id/summary"
+                style="@style/HomeItemSummaryText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="summary" />
+
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="-4dp"
+            android:background="?android:selectableItemBackgroundBorderless"
+            android:importantForAccessibility="no"
+            android:padding="4dp"
+            android:tintMode="src_in"
+            tools:src="@drawable/ic_trustworthy_24"
+            tools:tint="?colorSafe" />
 
         <TextView
-            android:id="@+id/title"
-            style="@style/HomeItemTitleText"
-            android:layout_width="match_parent"
+            android:id="@+id/text1"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="title" />
-
-        <TextView
-            android:id="@+id/summary"
-            style="@style/HomeItemSummaryText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:text="summary" />
+            android:background="@null"
+            android:fontFamily="sans-serif"
+            android:letterSpacing="0"
+            android:minWidth="0dp"
+            android:textColor="?colorAccent"
+            android:textStyle="bold"
+            tools:text="SW" />
 
     </LinearLayout>
 
-    <ImageView
-        android:id="@+id/icon"
+    <LinearLayout
+        android:id="@+id/btnCopy"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="-4dp"
-        android:background="?android:selectableItemBackgroundBorderless"
-        android:importantForAccessibility="no"
-        android:padding="4dp"
-        android:tintMode="src_in"
-        tools:src="@drawable/ic_trustworthy_24"
-        tools:tint="?colorSafe" />
+        android:layout_marginTop="8dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="gone">
 
-    <TextView
-        android:id="@+id/text1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@null"
-        android:fontFamily="sans-serif"
-        android:letterSpacing="0"
-        android:minWidth="0dp"
-        android:textColor="?colorAccent"
-        android:textStyle="bold"
-        tools:text="SW" />
+        <ImageView
+            android:id="@+id/imgCopy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="3dp"
+            android:layout_marginRight="3dp"
+            android:layout_weight="1"
+            android:background="@null"
+            android:contentDescription="@string/copy_vbhash"
+            android:src="?attr/actionModeCopyDrawable" />
+
+        <TextView
+            android:id="@+id/textCopy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@null"
+            android:fontFamily="sans-serif"
+            android:letterSpacing="0"
+            android:minWidth="0dp"
+            android:text="@string/copy_vbhash"
+            android:textAllCaps="true"
+            android:textColor="?colorAccent"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -34,6 +34,11 @@
         android:title="@string/attest_device_props" />
 
     <item
+        android:id="@+id/menu_copy_vbhash"
+        android:showAsAction="never"
+        android:title="@string/copy_vbhash" />
+
+    <item
         android:id="@+id/menu_reset"
         android:showAsAction="never"
         android:title="@string/reset" />

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4,6 +4,7 @@
     <string name="use_strongbox">Usar StrongBox</string>
     <string name="use_attest_key">Usar chave de atestado gerada pelo app</string>
     <string name="attest_device_props">Atestar props do dispositivo</string>
+    <string name="copy_vbhash">Copiar verified boot hash</string>
     <string name="reset">Redefinir</string>
     <string name="load_certs">Carregar do arquivo</string>
     <string name="save_certs">Salvar em arquivo</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -4,6 +4,7 @@
     <string name="use_strongbox">使用 StrongBox</string>
     <string name="use_attest_key">使用应用生成的认证密钥</string>
     <string name="attest_device_props">认证设备属性</string>
+    <string name="copy_vbhash">复制 verified boot hash</string>
     <string name="reset">重置</string>
     <string name="load_certs">从文件加载</string>
     <string name="save_certs">保存到文件</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name">金鑰認證</string>
     <string name="use_strongbox">使用 StrongBox</string>
     <string name="attest_device_props">認證裝置屬性</string>
+    <string name="copy_vbhash">複製 verified boot hash</string>
     <string name="about">關於</string>
     <string name="open_source_info"><![CDATA[
 此軟體是 %2$s 下的開源軟體（%1$s）。

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="use_strongbox">Use StrongBox</string>
     <string name="use_attest_key">Use app generated attest key</string>
     <string name="attest_device_props">Attest device props</string>
+    <string name="copy_vbhash">Copy verified boot hash</string>
     <string name="reset">Reset</string>
     <string name="load_certs">Load from file</string>
     <string name="save_certs">Save to file</string>


### PR DESCRIPTION
Users wanting to copy their verifiedBootHash for the "Detected Abnormal Boot State" and "Partition Modified" root detections bypass, can now copy the hash to their clipboard.

Examples:
[<img src="https://github.com/user-attachments/assets/3460b9ea-80c8-4169-bfeb-f089afaf23ae" width=50% />](https://github.com/user-attachments/assets/3460b9ea-80c8-4169-bfeb-f089afaf23ae)

[<img src="https://github.com/user-attachments/assets/dae215f1-5244-4cbf-ab92-4252eed57c47" width=50% />](https://github.com/user-attachments/assets/dae215f1-5244-4cbf-ab92-4252eed57c47)